### PR TITLE
feat: add AdminConfig and AdminSeeder for initial admin user setup

### DIFF
--- a/src/main/java/com/ludus/infra/config/AdminConfig.java
+++ b/src/main/java/com/ludus/infra/config/AdminConfig.java
@@ -1,0 +1,16 @@
+package com.ludus.infra.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Configuration
+@ConfigurationProperties(prefix = "admin.default")
+public class AdminConfig {
+
+    private String email;
+    private String password;
+}

--- a/src/main/java/com/ludus/seeders/AdminSeeder.java
+++ b/src/main/java/com/ludus/seeders/AdminSeeder.java
@@ -1,0 +1,41 @@
+package com.ludus.seeders;
+
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Component;
+import com.ludus.enums.UserRole;
+import com.ludus.infra.config.AdminConfig;
+import com.ludus.models.UserModel;
+import com.ludus.repositories.UserRepository;
+import com.ludus.services.UserService;
+import org.slf4j.Logger;
+
+@Component
+public class AdminSeeder implements CommandLineRunner {
+
+    private final UserService userService;
+    private static final Logger log = LoggerFactory.getLogger(AdminSeeder.class);
+    private final AdminConfig adminConfig;
+    private final UserRepository userRepository;
+
+    public AdminSeeder(UserService userService, AdminConfig adminConfig, UserRepository userRepository) {
+        this.userService = userService;
+        this.adminConfig = adminConfig;
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public void run(String... args) {
+        if (userService.findByEmail(adminConfig.getEmail()).isEmpty()) {
+            UserModel admin = new UserModel();
+
+            admin.setName("Admin");
+            admin.setEmail(adminConfig.getEmail());
+            admin.setPassword(new BCryptPasswordEncoder().encode(adminConfig.getPassword()));
+            admin.setRole(UserRole.ADMIN);
+            userRepository.save(admin);
+            log.info("ADMIN user created");
+        }
+    }
+}

--- a/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -13,5 +13,15 @@
     "name": "api.security.token.secret",
     "type": "java.lang.String",
     "description": "Secret key used for JWT token generation and validation"
+  },
+  {
+    "name": "admin.default.email",
+    "type": "java.lang.String",
+    "description": "Default email address used for creating the initial admin account"
+  },
+  {
+    "name": "admin.default.password",
+    "type": "java.lang.String",
+    "description": "Default password used for creating the initial admin account"
   }
 ]}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -36,3 +36,7 @@ springdoc.default-consumes-media-type=application/json
 # Settings
 api.base_url=${API_BASEURL:http://localhost:8080/api/${api.version}}
 api.version=v1
+
+# Admin user
+admin.default.email=${ADMIN_DEFAULT_EMAIL:adminlgs@email.com}
+admin.default.password=${ADMIN_DEFAULT_PASSWORD:puzzle001@}


### PR DESCRIPTION
This pull request introduces functionality to configure and seed a default admin user in the system. It includes the addition of a configuration class, a seeder for creating the admin user, and corresponding updates to application properties and metadata files.

### Admin Configuration and Seeding:

* [`src/main/java/com/ludus/infra/config/AdminConfig.java`](diffhunk://#diff-15cfaff5eab527f293f6d86e7e60b8a99e050e6cba4c7fcddb567e2c1899d5b2R1-R16): Added a new configuration class, `AdminConfig`, to manage default admin email and password properties using Spring's `@ConfigurationProperties`.
* [`src/main/java/com/ludus/seeders/AdminSeeder.java`](diffhunk://#diff-ec18b39cbb05cd7bfb557f82ff352f9b85613053fee8a623708ac939dcdf8541R1-R41): Introduced an `AdminSeeder` class implementing `CommandLineRunner` to create a default admin user at application startup if one does not already exist. The admin's credentials are fetched from `AdminConfig`.

### Application Properties and Metadata Updates:

* [`src/main/resources/application.properties`](diffhunk://#diff-54eeffbae371fcd1398d4ca5e89a1b8118208b7bb2f8ddf55c1aa2f7d98ab136R39-R42): Added properties `admin.default.email` and `admin.default.password` with default values to configure the admin account.
* [`src/main/resources/META-INF/additional-spring-configuration-metadata.json`](diffhunk://#diff-02914cc941fb98b26574abf3bc22cb5e395c6ac201bf8b6569610dfa299383c6R16-R25): Updated metadata to document the new `admin.default.email` and `admin.default.password` properties.